### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.3",
     "express-sesssion": "^1.15.5",
-    "npm": "^6.0.0",
     "request": "^2.85.0"
   }
 }


### PR DESCRIPTION

Hello mblaul!

It seems like you have npm as one of your (dev-) dependency in song-saver.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
